### PR TITLE
Fix Reading of empty files

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -112,9 +112,11 @@ fn file_open_read_with_option_do(file: &Path, mut options: ReadOptions) -> Resul
 
     // read magic bytes
     let mut buffer = [0; 6];
-    bufread.read_exact(&mut buffer).chain_err(|| {
-        format!("Failed to read file header of {:?}", file)
-    })?;
+    if let Err(_) = bufread.read_exact(&mut buffer) {
+        // reset buffer into a valid state
+        // this will trigger the plaintext case below
+        buffer = [0; 6];
+    };
     // reset the read position
     bufread.seek(SeekFrom::Start(0)).chain_err(
         || "Failed to seek to start of file.",

--- a/tests/read-write.rs
+++ b/tests/read-write.rs
@@ -19,30 +19,35 @@ et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
 sanctus est Lorem ipsum dolor sit amet."#;
 
 #[test]
+fn test_read_empty_file() {
+    do_read_test(Path::new("./tests/data/empty.txt"), "");
+}
+
+#[test]
 fn test_read_plaintext() {
-    do_read_test(Path::new("./tests/data/lorem.txt"));
+    do_read_test(Path::new("./tests/data/lorem.txt"), LOREM_IPSUM);
 }
 
 #[test]
 fn test_read_bz2() {
-    do_read_test(Path::new("./tests/data/lorem.txt.bz2"));
+    do_read_test(Path::new("./tests/data/lorem.txt.bz2"), LOREM_IPSUM);
 }
 
 #[test]
 fn test_read_gz() {
-    do_read_test(Path::new("./tests/data/lorem.txt.gz"));
+    do_read_test(Path::new("./tests/data/lorem.txt.gz"), LOREM_IPSUM);
 }
 
 #[test]
 fn test_read_xz() {
-    do_read_test(Path::new("./tests/data/lorem.txt.xz"));
+    do_read_test(Path::new("./tests/data/lorem.txt.xz"), LOREM_IPSUM);
 }
 
-fn do_read_test(file: &Path) {
+fn do_read_test(file: &Path, expected: &str) {
     let mut reader = file_open_read(Path::new(file)).unwrap();
     let mut content = String::new();
     reader.read_to_string(&mut content).unwrap();
-    assert_eq!(content, LOREM_IPSUM);
+    assert_eq!(content, expected);
 }
 
 #[test]


### PR DESCRIPTION
Probing for the filetype requires reading the first six bytes of a file.
If the file is empty this fails, so just assume it is a plaintext file
in this case.

Fixes #2