### PR TITLE
Set html_root_url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "misc_utils"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Jonas Bushart <jonas@bushart.org>"]
 description = "A small collection of convenient and utility functions developed for personal use."
 documentation = "https://docs.rs/misc_utils/"
@@ -35,6 +35,7 @@ pretty_assertions = "0.5"
 # Optional dev-dependencies are not a thing :(
 serde_derive = "1.0"
 tempfile = "3.0"
+version-sync = "0.7.0"
 
 [package.metadata.docs.rs]
 # https://github.com/onur/docs.rs/pull/131

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![warn(
     rust_2018_idioms,
 )]
+#![doc(html_root_url = "https://docs.rs/misc_utils/2.3.1")]
 
 //! This crate contains miscellaneous utility functions
 //!

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,0 +1,6 @@
+use version_sync::assert_html_root_url_updated;
+
+#[test]
+fn test_html_root_url() {
+    assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION

This allows rustdoc to link to this crate even with --no-deps.
Bump version to release these changes.