### PR TITLE
Make the support for different compression formats optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ script:
   - set -e
   - cargo build --verbose --no-default-features --all
   - cargo build --verbose --all
+  - cargo build --verbose --all-features --all
   # skip this step if clippy is not available, e.g., bad nightly
   # `|| true` to make the command always succeed, because the `set -e` would fail otherwise
   - ( which cargo-clippy >/dev/null 2>&1 && cargo clippy --verbose --all ) || true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "misc_utils"
-version = "2.4.0"
+version = "2.5.0"
 authors = ["Jonas Bushart <jonas@bushart.org>"]
 description = "A small collection of convenient and utility functions developed for personal use."
 documentation = "https://docs.rs/misc_utils/"
@@ -15,19 +15,26 @@ name = "misc_utils"
 path = "src/lib.rs"
 
 [dependencies]
-bzip2 = "0.3"
+bzip2 = { version = "0.3", optional = true }
 failure = "0.1.1"
-flate2 = "1.0"
+flate2 = { version = "1.0", optional = true }
 log = "0.4"
 num-traits = "0.2.6"
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
-xz2 = "0.1"
+xz2 = { version = "0.1", optional = true }
 
 [features]
-default = ["jsonl"]
+default = [
+    "file-gz",
+    "file-xz",
+    "jsonl",
+]
 # A nice multi-threaded JSONL iterator which puts file reading and JSON parsing into its own
 # threads.
+file-bz2 = ["bzip2"]
+file-gz = ["flate2"]
+file-xz = ["xz2"]
 jsonl = ["serde", "serde_json"]
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,8 @@
     unused_qualifications,
     variant_size_differences
 )]
-#![warn(
-    rust_2018_idioms,
-)]
-#![doc(html_root_url = "https://docs.rs/misc_utils/2.4.0")]
+#![warn(rust_2018_idioms)]
+#![doc(html_root_url = "https://docs.rs/misc_utils/2.5.0")]
 
 //! This crate contains miscellaneous utility functions
 //!

--- a/tests/jsonl.rs
+++ b/tests/jsonl.rs
@@ -21,6 +21,7 @@ struct Deserializeable {
     value: Value,
 }
 
+#[cfg_attr(not(feature = "file-xz"), ignore)]
 #[test]
 fn test_read_compressed_jsonl() {
     let mut iter = parse_jsonl_multi_threaded::<_, (u64, u64)>("./tests/data/jsonl.xz", 1024);

--- a/tests/read-write.rs
+++ b/tests/read-write.rs
@@ -1,10 +1,11 @@
-use misc_utils::fs::{self, file_open_read, file_open_write, Compression, FileType, WriteOptions};
+use misc_utils::fs::{self, file_open_read, file_open_write, WriteOptions};
+#[cfg(any(feature = "file-gz", feature = "file-xz", feature = "file-bz2"))]
+use misc_utils::fs::{Compression, FileType};
 use pretty_assertions::assert_eq;
 use std::{fs::File, io::prelude::*, path::Path};
 use tempfile::{Builder, NamedTempFile};
 
-const LOREM_IPSUM: &str =
-    r#"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+const LOREM_IPSUM: &str = r#"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
 vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
 no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
@@ -69,16 +70,19 @@ fn test_read_plaintext() {
     do_read_test(Path::new("./tests/data/lorem.txt"), LOREM_IPSUM);
 }
 
+#[cfg_attr(not(feature = "file-bz2"), ignore)]
 #[test]
 fn test_read_bz2() {
     do_read_test(Path::new("./tests/data/lorem.txt.bz2"), LOREM_IPSUM);
 }
 
+#[cfg_attr(not(feature = "file-gz"), ignore)]
 #[test]
 fn test_read_gz() {
     do_read_test(Path::new("./tests/data/lorem.txt.gz"), LOREM_IPSUM);
 }
 
+#[cfg_attr(not(feature = "file-xz"), ignore)]
 #[test]
 fn test_read_xz() {
     do_read_test(Path::new("./tests/data/lorem.txt.xz"), LOREM_IPSUM);
@@ -90,6 +94,7 @@ fn test_write_plaintext() {
     do_write_test(Path::new("./tests/data/lorem.txt"), options);
 }
 
+#[cfg(feature = "file-bz2")]
 #[test]
 fn test_write_bzip2() {
     let options = WriteOptions::default()
@@ -98,6 +103,7 @@ fn test_write_bzip2() {
     do_write_test(Path::new("./tests/data/lorem.txt.bz2"), options);
 }
 
+#[cfg(feature = "file-gz")]
 #[test]
 fn test_write_gzip() {
     let options = WriteOptions::default()
@@ -106,6 +112,7 @@ fn test_write_gzip() {
     do_write_test(Path::new("./tests/data/lorem.txt.gz"), options);
 }
 
+#[cfg(feature = "file-xz")]
 #[test]
 fn test_write_xz() {
     let options = WriteOptions::default()
@@ -124,16 +131,19 @@ fn test_read_plaintext_fs_bytes() {
     do_read_test_fs_bytes(Path::new("./tests/data/lorem.txt"), LOREM_IPSUM);
 }
 
+#[cfg_attr(not(feature = "file-bz2"), ignore)]
 #[test]
 fn test_read_bz2_fs_bytes() {
     do_read_test_fs_bytes(Path::new("./tests/data/lorem.txt.bz2"), LOREM_IPSUM);
 }
 
+#[cfg_attr(not(feature = "file-gz"), ignore)]
 #[test]
 fn test_read_gz_fs_bytes() {
     do_read_test_fs_bytes(Path::new("./tests/data/lorem.txt.gz"), LOREM_IPSUM);
 }
 
+#[cfg_attr(not(feature = "file-xz"), ignore)]
 #[test]
 fn test_read_xz_fs_bytes() {
     do_read_test_fs_bytes(Path::new("./tests/data/lorem.txt.xz"), LOREM_IPSUM);
@@ -149,16 +159,19 @@ fn test_read_plaintext_fs_string() {
     do_read_test_fs_string(Path::new("./tests/data/lorem.txt"), LOREM_IPSUM);
 }
 
+#[cfg_attr(not(feature = "file-bz2"), ignore)]
 #[test]
 fn test_read_bz2_fs_string() {
     do_read_test_fs_string(Path::new("./tests/data/lorem.txt.bz2"), LOREM_IPSUM);
 }
 
+#[cfg_attr(not(feature = "file-gz"), ignore)]
 #[test]
 fn test_read_gz_fs_string() {
     do_read_test_fs_string(Path::new("./tests/data/lorem.txt.gz"), LOREM_IPSUM);
 }
 
+#[cfg_attr(not(feature = "file-xz"), ignore)]
 #[test]
 fn test_read_xz_fs_string() {
     do_read_test_fs_string(Path::new("./tests/data/lorem.txt.xz"), LOREM_IPSUM);
@@ -169,16 +182,19 @@ fn test_write_plaintext_fs() {
     do_write_test_fs(Path::new("./tests/data/lorem.txt"), ".txt");
 }
 
+#[cfg_attr(not(feature = "file-bz2"), ignore)]
 #[test]
 fn test_write_bzip2_fs() {
     do_write_test_fs(Path::new("./tests/data/lorem.txt.default.bz2"), ".bz2");
 }
 
+#[cfg_attr(not(feature = "file-gz"), ignore)]
 #[test]
 fn test_write_gzip_fs() {
     do_write_test_fs(Path::new("./tests/data/lorem.txt.default.gz"), ".gz");
 }
 
+#[cfg_attr(not(feature = "file-xz"), ignore)]
 #[test]
 fn test_write_xz_fs() {
     do_write_test_fs(Path::new("./tests/data/lorem.txt.default.xz"), ".xz");


### PR DESCRIPTION

By default the support for bz2 is disabled, but compression file support
can be enabled with the `file-*` features.