### PR TITLE
Do not run CI on push to some branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: Rust CI
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
   pull_request:
   # Run every Saturday night
   schedule:


### PR DESCRIPTION
dependabot and pre-commit CI only update dependencies and always create
a PRs. Running CI on push is not necessary and even causes problems for
the SARIF upload, since dependabot branches are read-only.

bors merge