### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,20 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: saturday
-    time: '01:00'
-  open-pull-requests-limit: 20
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: saturday
-    time: '01:00'
-  open-pull-requests-limit: 20
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "01:00"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 20
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "01:00"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 20


### PR DESCRIPTION
This limits how quickly new dependencies are considered for updates.